### PR TITLE
feat: update hashing flow to use argon2

### DIFF
--- a/app/pages/signup.vue
+++ b/app/pages/signup.vue
@@ -26,7 +26,10 @@ const schema = z.object({
   emailAddress: z.string().email(),
   familyName: z.string(),
   givenName: z.string(),
-  password: z.string().min(8, "Must be at least 8 characters"),
+  password: z
+    .string()
+    .min(12, "Must be at least 12 characters")
+    .max(128, "Must be at most 128 characters"), // Updated password policy
 });
 
 type Schema = z.output<typeof schema>;

--- a/package.json
+++ b/package.json
@@ -26,7 +26,7 @@
   "dependencies": {
     "@paralleldrive/cuid2": "3.3.0",
     "@vueuse/core": "14.2.1",
-    "bcrypt": "6.0.0",
+    "argon2": "^0.44.0",
     "date-fns": "4.1.0",
     "kysely": "0.28.16",
     "kysely-postgres-js": "3.0.0",
@@ -77,7 +77,8 @@
       "esbuild",
       "prisma",
       "unrs-resolver",
-      "vue-demi"
+      "vue-demi",
+      "argon2"
     ]
   }
 }

--- a/pnpm-lock.yaml
+++ b/pnpm-lock.yaml
@@ -14,9 +14,9 @@ importers:
       '@vueuse/core':
         specifier: 14.2.1
         version: 14.2.1(vue@3.5.33(typescript@6.0.3))
-      bcrypt:
-        specifier: 6.0.0
-        version: 6.0.0
+      argon2:
+        specifier: ^0.44.0
+        version: 0.44.0
       date-fns:
         specifier: 4.1.0
         version: 4.1.0
@@ -104,7 +104,7 @@ importers:
         version: 4.4.2(@babel/core@7.29.0)(@babel/plugin-syntax-jsx@7.28.6(@babel/core@7.29.0))(@electric-sql/pglite@0.4.1)(@emnapi/core@1.10.0)(@emnapi/runtime@1.10.0)(@parcel/watcher@2.5.6)(@types/node@25.6.0)(@vitejs/devtools@0.1.15(@pnpm/logger@1001.0.1)(db0@0.3.4(@electric-sql/pglite@0.4.1)(mysql2@3.15.3))(ioredis@5.10.1)(typescript@6.0.3)(vite@7.3.2(@types/node@25.6.0)(jiti@2.6.1)(lightningcss@1.32.0)(terser@5.46.2)(tsx@4.21.0)(yaml@2.8.3)))(@vue/compiler-sfc@3.5.33)(cac@6.7.14)(db0@0.3.4(@electric-sql/pglite@0.4.1)(mysql2@3.15.3))(eslint@10.2.1(jiti@2.6.1))(ioredis@5.10.1)(lightningcss@1.32.0)(magicast@0.5.2)(mysql2@3.15.3)(optionator@0.9.4)(rollup-plugin-visualizer@7.0.1(rollup@4.60.2))(rollup@4.60.2)(srvx@0.11.15)(terser@5.46.2)(tsx@4.21.0)(typescript@6.0.3)(vite@7.3.2(@types/node@25.6.0)(jiti@2.6.1)(lightningcss@1.32.0)(terser@5.46.2)(tsx@4.21.0)(yaml@2.8.3))(yaml@2.8.3)
       nuxt-auth-utils:
         specifier: 0.5.29
-        version: 0.5.29(bcrypt@6.0.0)(magicast@0.5.2)
+        version: 0.5.29(argon2@0.44.0)(bcrypt@6.0.0)(magicast@0.5.2)
       prettier:
         specifier: 3.8.3
         version: 3.8.3
@@ -363,6 +363,9 @@ packages:
 
   '@emnapi/wasi-threads@1.2.1':
     resolution: {integrity: sha512-uTII7OYF+/Mes/MrcIOYp5yOtSMLBWSIoLPpcgwipoiKbli6k322tcoFsxoIIxPDqW01SQGAgko4EzZi2BNv2w==}
+
+  '@epic-web/invariant@1.0.0':
+    resolution: {integrity: sha512-lrTPqgvfFQtR/eY/qkIzp98OGdNJu0m5ji3q/nJI8v3SXkRKEnWiOxMmbvcSoAIzv/cGiuvRy57k4suKQSAdwA==}
 
   '@es-joy/jsdoccomment@0.86.0':
     resolution: {integrity: sha512-ukZmRQ81WiTpDWO6D/cTBM7XbrNtutHKvAVnZN/8pldAwLoJArGOvkNyxPTBGsPjsoaQBJxlH+tE2TNA/92Qgw==}
@@ -2813,6 +2816,10 @@ packages:
   arg@5.0.2:
     resolution: {integrity: sha512-PYjyFOLKQ9y57JvQ6QLo8dAgNqswh8M1RMJYdQduT6xbWSgK36P/Z/v+p888pM69jMMfS8Xd8F6I1kQ/I9HUGg==}
 
+  argon2@0.44.0:
+    resolution: {integrity: sha512-zHPGN3S55sihSQo0dBbK0A5qpi2R31z7HZDZnry3ifOyj8bZZnpZND2gpmhnRGO1V/d555RwBqIK5W4Mrmv3ig==}
+    engines: {node: '>=16.17.0'}
+
   argparse@2.0.1:
     resolution: {integrity: sha512-8+9WqebbFzpX9OR+Wa6O29asIogeRMzcGtAINdpMHHyAg10f05aSFVBbcEqGf/PXw1EjAZ+q2/bEBg3DvurK3Q==}
 
@@ -3180,6 +3187,11 @@ packages:
   croner@10.0.1:
     resolution: {integrity: sha512-ixNtAJndqh173VQ4KodSdJEI6nuioBWI0V1ITNKhZZsO0pEMoDxz539T4FTTbSZ/xIOSuDnzxLVRqBVSvPNE2g==}
     engines: {node: '>=18.0'}
+
+  cross-env@10.1.0:
+    resolution: {integrity: sha512-GsYosgnACZTADcmEyJctkJIoqAhHjttw7RsFrVoJNXbsWWqaq6Ym+7kZjq6mS45O0jij6vtiReppKQEtqWy6Dw==}
+    engines: {node: '>=20'}
+    hasBin: true
 
   cross-spawn@7.0.6:
     resolution: {integrity: sha512-uV2QOWP2nWzsy2aMp8aRibhi9dlzF5Hgh5SHaB9OiTGEyDTiJJyx0uy51QXdyWbtAHNua4XJzUKca3OzKUd3vA==}
@@ -6807,11 +6819,12 @@ packages:
 
 snapshots:
 
-  '@adonisjs/hash@9.1.1(bcrypt@6.0.0)':
+  '@adonisjs/hash@9.1.1(argon2@0.44.0)(bcrypt@6.0.0)':
     dependencies:
       '@phc/format': 1.0.0
       '@poppinss/utils': 6.10.1
     optionalDependencies:
+      argon2: 0.44.0
       bcrypt: 6.0.0
 
   '@alloc/quick-lru@5.2.0': {}
@@ -7083,6 +7096,8 @@ snapshots:
     dependencies:
       tslib: 2.8.1
     optional: true
+
+  '@epic-web/invariant@1.0.0': {}
 
   '@es-joy/jsdoccomment@0.86.0':
     dependencies:
@@ -9881,6 +9896,13 @@ snapshots:
 
   arg@5.0.2: {}
 
+  argon2@0.44.0:
+    dependencies:
+      '@phc/format': 1.0.0
+      cross-env: 10.1.0
+      node-addon-api: 8.7.0
+      node-gyp-build: 4.8.4
+
   argparse@2.0.1: {}
 
   aria-hidden@1.2.6:
@@ -10016,6 +10038,7 @@ snapshots:
     dependencies:
       node-addon-api: 8.7.0
       node-gyp-build: 4.8.4
+    optional: true
 
   better-result@2.8.2: {}
 
@@ -10239,6 +10262,11 @@ snapshots:
       readable-stream: 4.7.0
 
   croner@10.0.1: {}
+
+  cross-env@10.1.0:
+    dependencies:
+      '@epic-web/invariant': 1.0.0
+      cross-spawn: 7.0.6
 
   cross-spawn@7.0.6:
     dependencies:
@@ -12232,9 +12260,9 @@ snapshots:
     dependencies:
       boolbase: 1.0.0
 
-  nuxt-auth-utils@0.5.29(bcrypt@6.0.0)(magicast@0.5.2):
+  nuxt-auth-utils@0.5.29(argon2@0.44.0)(bcrypt@6.0.0)(magicast@0.5.2):
     dependencies:
-      '@adonisjs/hash': 9.1.1(bcrypt@6.0.0)
+      '@adonisjs/hash': 9.1.1(argon2@0.44.0)(bcrypt@6.0.0)
       '@nuxt/kit': 4.4.2(magicast@0.5.2)
       defu: 6.1.7
       h3: 1.15.11

--- a/server/api/auth/login.post.ts
+++ b/server/api/auth/login.post.ts
@@ -1,5 +1,5 @@
 import { z } from "zod";
-import { compare } from "bcrypt";
+import { verify } from "argon2";
 
 const loginSchema = z.object({
   emailAddress: z.string().email(),
@@ -46,7 +46,7 @@ export default defineEventHandler(async (event) => {
   }
 
   // Check if the password matches
-  if (!(await compare(body.data.password, user.password))) {
+  if (!(await verify(user.password, body.data.password))) {
     throw createError({
       statusCode: 401,
       statusMessage: "Invalid email address or password",

--- a/server/api/auth/login.post.ts
+++ b/server/api/auth/login.post.ts
@@ -22,10 +22,12 @@ export default defineEventHandler(async (event) => {
     });
   }
 
+  const normalizedEmail = body.data.emailAddress.trim().toLowerCase(); // Normalize email
+
   // Get the user from the database
   const user = await prisma.user.findUnique({
     where: {
-      emailAddress: body.data.emailAddress,
+      emailAddress: normalizedEmail, // Use normalized email
     },
   });
 

--- a/server/api/auth/signup.post.ts
+++ b/server/api/auth/signup.post.ts
@@ -4,6 +4,7 @@ import { nanoid } from "nanoid";
 import dayjs from "dayjs";
 import { sendEmail } from "../../utils/sendEmail";
 import { randomBytes } from "crypto";
+import { createHash } from "crypto";
 
 const signupSchema = z.object({
   emailAddress: z.string().email(),
@@ -48,7 +49,10 @@ export default defineEventHandler(async (event) => {
   // Create a new user
   const salt = randomBytes(16); // Generate a 16-byte salt
   const hashedPassword = await hash(body.data.password, { salt }); // Pass the salt to argon2
-  const verificationToken = nanoid();
+  const rawToken = nanoid();
+  const hashedToken = createHash("sha256").update(rawToken).digest("hex");
+
+  const verificationToken = rawToken; // Send raw token via email
   const tokenExpiry = dayjs().add(30, "minute").toDate();
 
   const newUser = await prisma.user.create({
@@ -56,7 +60,7 @@ export default defineEventHandler(async (event) => {
       emailAddress: body.data.emailAddress,
       // If email verification is enabled, we need to store the verification token and expiry date
       emailVerificationToken: emailVerificationEnabled
-        ? verificationToken
+        ? hashedToken // Store hashed token in DB
         : null,
       emailVerificationTokenExpires: emailVerificationEnabled
         ? tokenExpiry

--- a/server/api/auth/signup.post.ts
+++ b/server/api/auth/signup.post.ts
@@ -10,7 +10,7 @@ const signupSchema = z.object({
   emailAddress: z.string().email(),
   familyName: z.string(),
   givenName: z.string(),
-  password: z.string().min(8),
+  password: z.string().min(12).max(128), // Updated password policy
 });
 
 export default defineEventHandler(async (event) => {
@@ -30,10 +30,12 @@ export default defineEventHandler(async (event) => {
     });
   }
 
+  const normalizedEmail = body.data.emailAddress.trim().toLowerCase(); // Normalize email
+
   // Check if the user already exists
   const user = await prisma.user.findUnique({
     where: {
-      emailAddress: body.data.emailAddress,
+      emailAddress: normalizedEmail, // Use normalized email
     },
   });
 
@@ -47,8 +49,8 @@ export default defineEventHandler(async (event) => {
   const emailVerificationEnabled = config.public.ENABLE_EMAIL_VERIFICATION;
 
   // Create a new user
-  const salt = randomBytes(16); // Generate a 16-byte salt
-  const hashedPassword = await hash(body.data.password, { salt }); // Pass the salt to argon2
+  const hashedPassword = await hash(body.data.password);
+
   const rawToken = nanoid();
   const hashedToken = createHash("sha256").update(rawToken).digest("hex");
 
@@ -57,7 +59,7 @@ export default defineEventHandler(async (event) => {
 
   const newUser = await prisma.user.create({
     data: {
-      emailAddress: body.data.emailAddress,
+      emailAddress: normalizedEmail, // Store normalized email
       // If email verification is enabled, we need to store the verification token and expiry date
       emailVerificationToken: emailVerificationEnabled
         ? hashedToken // Store hashed token in DB

--- a/server/api/auth/signup.post.ts
+++ b/server/api/auth/signup.post.ts
@@ -1,8 +1,9 @@
 import { z } from "zod";
-import { hash } from "bcrypt";
+import { hash } from "argon2";
 import { nanoid } from "nanoid";
 import dayjs from "dayjs";
 import { sendEmail } from "../../utils/sendEmail";
+import { randomBytes } from "crypto";
 
 const signupSchema = z.object({
   emailAddress: z.string().email(),
@@ -45,7 +46,8 @@ export default defineEventHandler(async (event) => {
   const emailVerificationEnabled = config.public.ENABLE_EMAIL_VERIFICATION;
 
   // Create a new user
-  const hashedPassword = await hash(body.data.password, 10);
+  const salt = randomBytes(16); // Generate a 16-byte salt
+  const hashedPassword = await hash(body.data.password, { salt }); // Pass the salt to argon2
   const verificationToken = nanoid();
   const tokenExpiry = dayjs().add(30, "minute").toDate();
 

--- a/server/api/auth/verify-email.post.ts
+++ b/server/api/auth/verify-email.post.ts
@@ -1,4 +1,5 @@
 import { z } from "zod";
+import { createHash } from "crypto";
 
 const verifySchema = z.object({
   token: z.string(),
@@ -14,10 +15,15 @@ export default defineEventHandler(async (event) => {
     });
   }
 
-  // Find the user by verification token
+  // Hash the incoming token
+  const hashedToken = createHash("sha256")
+    .update(body.data.token)
+    .digest("hex");
+
+  // Find the user by hashed verification token
   const user = await prisma.user.findUnique({
     where: {
-      emailVerificationToken: body.data.token,
+      emailVerificationToken: hashedToken, // Compare hashed token
     },
   });
 


### PR DESCRIPTION
## Summary by Sourcery

Switch authentication to use argon2-based password hashing and improve account security and consistency across signup, login, and email verification.

New Features:
- Normalize email addresses on signup and login before persisting or querying users.

Bug Fixes:
- Store and compare hashed email verification tokens instead of raw tokens to avoid exposing secrets in the database.

Enhancements:
- Increase password complexity requirements on both backend and frontend validation to require 12–128 character passwords.
- Replace bcrypt with argon2 for password hashing and verification in the authentication flow.

Build:
- Update runtime dependencies and workspace configuration to depend on argon2 instead of bcrypt.